### PR TITLE
Adding Yuzu Early Access

### DIFF
--- a/platforms/NintendoSwitch.json
+++ b/platforms/NintendoSwitch.json
@@ -41,6 +41,16 @@
       "killPackageProcesses": false,
       "killPackageProcessesWarning": false,
       "extra": ""
+    },
+    {
+      "name": "switch - Yuzu - Early Access",
+      "uniqueId": "org.yuzu.yuzu_emu.ea",
+      "description": "Supported extensions: nro, nso, nca, xci, nsp.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:nro|nso|nca|xci|nsp)$",
+      "amStartArguments": "-n org.yuzu.yuzu_emu.ea/org.yuzu.yuzu_emu.activities.EmulationActivity\n  -a android.nfc.action.TECH_DISCOVERED\n  -d {file.uri}",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": false,
+      "extra": ""
     }
   ]
 }


### PR DESCRIPTION
There are two versions of Yuzu for switch.  The donate early access version has the bundle ID : org.yuzu.yuzu_emu.ea.  The activity name remains org.yuzu.yuzu_emu.activities.EmulationActivity.  This commit adds the version, but I'm not sure the discovery order for automatic configuration when adding a platform.  Should it be listed before non early access?