### PR TITLE
Update GameCube.json

### DIFF
--- a/platforms/GameCube.json
+++ b/platforms/GameCube.json
@@ -84,6 +84,16 @@
       "killPackageProcesses": false,
       "killPackageProcessesWarning": true,
       "extra": ""
+    },
+    {
+      "name": "gc - Dolphin Ishiiruka",
+      "uniqueId": "gc.org.dolphin.ishiirukadark",
+      "description": null,
+      "acceptedFilenameRegex": "^(.*).(?:ciao|dff|dol|elf|gcm|gcz|iso|tgc|wad|wbfs|rvz)$",
+      "amStartArguments": "-n org.dolphin.ishiirukadark/org.dolphinemu.dolphinemu.ui.main.MainActivity\n  -a android.intent.action.VIEW\n  -e AutoStartFile {file.path}",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": true,
+      "extra": ""
     }
   ]
 }


### PR DESCRIPTION
add Ishiiruka to optional launchers for wii/gc
Ishiiruka has a focus on lesser hardware or legacy devices, and has an async shader option to help improve performance. 