### PR TITLE
Fix MelonDS Nightly

### DIFF
--- a/platforms/NintendoDS.json
+++ b/platforms/NintendoDS.json
@@ -50,8 +50,8 @@
       "uniqueId": "nds.me.magnum.melonds.nightly",
       "description": null,
       "acceptedFilenameRegex": "^(.*).(?:nds|zip|7z)$",
-      "amStartArguments": "-a me.magnum.melonds.LAUNCH_ROM\n-n me.magnum.melonds.nightly/me.magnum.melonds.ui.emulator.EmulatorActivity\n-e uri {file.uri}",
-      "killPackageProcesses": false,
+      "amStartArguments": "-a me.magnum.melonds.nightly.LAUNCH_ROM\n-n me.magnum.melonds.nightly/me.magnum.melonds.ui.emulator.EmulatorActivity\n-e uri {file.uri}",
+      "killPackageProcesses": true,
       "killPackageProcessesWarning": false,
       "extra": ""
     },


### PR DESCRIPTION
it's missing a word, right now it can't find the emulator/activity.
![image](https://github.com/TapiocaFox/Daijishou/assets/48196637/c231e201-7176-4d25-aaf9-1f9db024172b)

After adding the missing part:
![scrcpy_BoH50OUgtq](https://github.com/TapiocaFox/Daijishou/assets/48196637/1b55fbf6-f52d-4c99-8f61-b9298bb39957)


You also want to enable kill package process before am start to not get a warning in the emulator
![image](https://github.com/TapiocaFox/Daijishou/assets/48196637/2cf831e6-8047-4848-8b67-85037adbd530)
