### PR TITLE
Add Borked3DS player

### DIFF
--- a/platforms/Nintendo3DS.json
+++ b/platforms/Nintendo3DS.json
@@ -1,6 +1,6 @@
 {
   "databaseVersion": 14,
-  "revisionNumber": 9,
+  "revisionNumber": 10,
   "platform": {
     "name": "Nintendo 3DS",
     "uniqueId": "3ds",
@@ -26,6 +26,16 @@
     "extra": ""
   },
   "playerList": [
+    {
+      "name": "3ds - Borked 3DS",
+      "uniqueId": "3ds.io.github.borked3ds.android",
+      "description": "Supported extensions: 3ds, 3dsx, app, axf, cci, cxi, elf.",
+      "acceptedFilenameRegex": "^(.*)\\.(?:3ds|3dsx|app|axf|cci|cxi|elf)$",
+      "amStartArguments": "-n io.github.borked3ds.android/.activities.EmulationActivity\n  -a android.intent.action.VIEW\n  -d {file.uri}\n  --activity-clear-task\n  --activity-clear-top\n",
+      "killPackageProcesses": false,
+      "killPackageProcessesWarning": true,
+      "extra": ""
+    },
     {
       "name": "3ds - Citra Nightly",
       "uniqueId": "3ds.org.citra.citra_emu",

--- a/platforms/index.json
+++ b/platforms/index.json
@@ -398,7 +398,7 @@
       "platformName": "Nintendo 3DS",
       "platformShortname": "3ds",
       "platformUniqueId": "3ds",
-      "revisionNumber": 9
+      "revisionNumber": 10
     },
     {
       "filename": "Nintendo64.json",


### PR DESCRIPTION
Needed this to fix a problem where the game window would stop refreshing. None of the other options in Daijishou worked.

Was originally created for Bravely Offline. Now it's the only mature Citra fork that's actively receiving updates/fixes. (Azahar waiting room.)

Has everything from the PabloMK7 fork with features from Lime3DS & Mandarine added in as well as doing its own thing.

Long explanation on its [GitHub page](https://github.com/Borked3DS/Borked3DS#differences-between-borked3ds-and-the-other-forks).

Added it as `Borked 3DS` (with a space) in the json since I noticed you added Lime3DS as `Lime 3DS`. (For readability probably?)

Tested and working on my device.